### PR TITLE
Update toolchain version for Ubuntu; compatibility with Ubuntu 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ Next, clone this repo and move to the cloned directory:
 ```
 git clone https://github.com/sdg2DieUpm/install-MatrixMCU.git && cd install-MatrixMCU
 ```
-Then, run the script `ubuntu.sh` in a terminal:
+Then, if your OS is Ubuntu 22, run the script `ubuntu22.sh` in a terminal:
 ```bash
-./ubuntu.sh
+source ubuntu22.sh
+```
+Alternatively, if your OS is Ubuntu 24, run the script `ubuntu24.sh` in a terminal:
+```bash
+source ubuntu24.sh
 ```
 Once you are done, reload the `.bashrc` settings on your terminal:
 ```bash

--- a/ubuntu22.sh
+++ b/ubuntu22.sh
@@ -7,7 +7,6 @@ sudo apt update
 sudo apt install build-essential
 
 # Install cmake
-# sudo apt install cmake
 sudo snap install cmake --classic
 
 # Install openocd
@@ -17,19 +16,19 @@ sudo apt install openocd
 sudo apt install gdb-multiarch
 
 # Create directories for the tools used in MatrixMCU course
-sudo mkdir /opt/MatrixMCU
-sudo mkdir /opt/MatrixMCU/bin
+sudo mkdir -p /opt/MatrixMCU/bin
 
 # Download arm toolchain zip file
-wget https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
+wget https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
 # Uncompress arm toolchain zip file in /usr/share directory
 sudo tar -xf /tmp/arm-toolchain.tar.xz -C /opt/MatrixMCU
 
 # Create symbolic links to arm toolchain in /opt/MatrixMCU/bin
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-nm /opt/MatrixMCU/bin/arm-none-eabi-nm
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
 
 # Get the path to gdb-multiarch...
 GDB_MULTIARCH_PATH=$(which gdb-multiarch)

--- a/ubuntu24.sh
+++ b/ubuntu24.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Update package list
+sudo apt update
+
+# Install build-essential
+sudo apt install build-essential
+
+# Install cmake
+sudo apt install cmake
+# sudo snap install cmake --classic
+
+# Install openocd
+sudo apt install openocd
+
+# Install gdb multiarch
+sudo apt install gdb-multiarch
+
+# Create directories for the tools used in MatrixMCU course
+sudo mkdir -p /opt/MatrixMCU/bin
+
+# Download arm toolchain zip file
+wget https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
+# Uncompress arm toolchain zip file in /usr/share directory
+sudo tar -xf /tmp/arm-toolchain.tar.xz -C /opt/MatrixMCU
+
+# Create symbolic links to arm toolchain in /opt/MatrixMCU/bin
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-nm /opt/MatrixMCU/bin/arm-none-eabi-nm
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
+
+# Get the path to gdb-multiarch...
+GDB_MULTIARCH_PATH=$(which gdb-multiarch)
+# ... and create a symbolic link to gdb-multiarch in /opt/MatrixMCU/bin with the name arm-none-eabi-gdb
+sudo ln -s $GDB_MULTIARCH_PATH /opt/MatrixMCU/bin/arm-none-eabi-gdb
+
+# Add /opt/MatrixMCU/bin to PATH
+echo 'export PATH=/opt/MatrixMCU/bin:$PATH # Required for MatrixMCU toolkit' >> ~/.bashrc


### PR DESCRIPTION
We still need instructions for WSL. The `README.md` contains a few instructions hidden, we might be able to reuse them.