### PR TITLE
Toolchain update

### DIFF
--- a/ubuntu22.sh
+++ b/ubuntu22.sh
@@ -20,7 +20,7 @@ sudo mkdir -p /opt/MatrixMCU/bin
 
 # Download arm toolchain zip file
 wget https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
-# Uncompress arm toolchain zip file in /usr/share directory
+# Uncompress arm toolchain zip file in /opt directory
 sudo tar -xf /tmp/arm-toolchain.tar.xz -C /opt/MatrixMCU
 
 # Create symbolic links to arm toolchain in /opt/MatrixMCU/bin

--- a/ubuntu22.sh
+++ b/ubuntu22.sh
@@ -19,16 +19,16 @@ sudo apt install gdb-multiarch
 sudo mkdir -p /opt/MatrixMCU/bin
 
 # Download arm toolchain zip file
-wget https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
+wget https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
 # Uncompress arm toolchain zip file in /usr/share directory
 sudo tar -xf /tmp/arm-toolchain.tar.xz -C /opt/MatrixMCU
 
 # Create symbolic links to arm toolchain in /opt/MatrixMCU/bin
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-nm /opt/MatrixMCU/bin/arm-none-eabi-nm
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-nm /opt/MatrixMCU/bin/arm-none-eabi-nm
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
 
 # Get the path to gdb-multiarch...
 GDB_MULTIARCH_PATH=$(which gdb-multiarch)

--- a/ubuntu24.sh
+++ b/ubuntu24.sh
@@ -21,7 +21,7 @@ sudo mkdir -p /opt/MatrixMCU/bin
 
 # Download arm toolchain zip file
 wget https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
-# Uncompress arm toolchain zip file in /usr/share directory
+# Uncompress arm toolchain zip file in /opt directory
 sudo tar -xf /tmp/arm-toolchain.tar.xz -C /opt/MatrixMCU
 
 # Create symbolic links to arm toolchain in /opt/MatrixMCU/bin

--- a/ubuntu24.sh
+++ b/ubuntu24.sh
@@ -20,16 +20,16 @@ sudo apt install gdb-multiarch
 sudo mkdir -p /opt/MatrixMCU/bin
 
 # Download arm toolchain zip file
-wget https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
+wget https://developer.arm.com/-/media/Files/downloads/gnu/15.2.rel1/binrel/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi.tar.xz -O /tmp/arm-toolchain.tar.xz
 # Uncompress arm toolchain zip file in /usr/share directory
 sudo tar -xf /tmp/arm-toolchain.tar.xz -C /opt/MatrixMCU
 
 # Create symbolic links to arm toolchain in /opt/MatrixMCU/bin
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-nm /opt/MatrixMCU/bin/arm-none-eabi-nm
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
-sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc /opt/MatrixMCU/bin/arm-none-eabi-gcc
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-g++ /opt/MatrixMCU/bin/arm-none-eabi-g++
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-nm /opt/MatrixMCU/bin/arm-none-eabi-nm
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objcopy /opt/MatrixMCU/bin/arm-none-eabi-objcopy
+sudo ln -s /opt/MatrixMCU/arm-gnu-toolchain-15.2.rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-objdump /opt/MatrixMCU/bin/arm-none-eabi-objdump
 
 # Get the path to gdb-multiarch...
 GDB_MULTIARCH_PATH=$(which gdb-multiarch)


### PR DESCRIPTION
- Updated ubuntu scripts to download the 15.2 toolchain
- Changed a comment about the location of the uncompressed contents from /usr/share to /opt